### PR TITLE
feat: add debt vs health and education statistics to key stats

### DIFF
--- a/output/key_stats.json
+++ b/output/key_stats.json
@@ -1,1 +1,1 @@
-{"debt_gni": "23.4%", "debt_stock_total": "US$3.56 trillion", "debt_service_total": "US$471.52 billion", "countries_debt_distress": 33, "latest_year": 2024, "last_data_update": "16 March 2026"}
+{"debt_gni": "23.4%", "debt_stock_total": "US$3.56 trillion", "debt_service_total": "US$471.52 billion", "countries_debt_distress": 33, "countries_debt_vs_health": 53, "countries_debt_vs_education": 24, "latest_year": 2024, "last_data_update": "20 March 2026"}

--- a/scripts/analysis/charts.py
+++ b/scripts/analysis/charts.py
@@ -562,6 +562,34 @@ def key_stats() -> None:
 
     stats_dict["countries_debt_distress"] = val
 
+    # countries where debt service > health/education spending (% of gov expenditure)
+    chart_8_df = pd.read_csv(Paths.output / "chart_8_chart.csv")
+    country_df = chart_8_df.loc[
+        lambda d: d.entity_code.notna() & (d.year <= GHED_END_YEAR)
+    ]
+
+    # latest year per country where both debt service and health exist
+    health_compare = (
+        country_df.dropna(subset=["debt service", "health"])
+        .sort_values("year")
+        .groupby("entity_code")
+        .last()
+    )
+    stats_dict["countries_debt_vs_health"] = int(
+        (health_compare["debt service"] > health_compare["health"]).sum()
+    )
+
+    # latest year per country where both debt service and education exist
+    edu_compare = (
+        country_df.dropna(subset=["debt service", "education"])
+        .sort_values("year")
+        .groupby("entity_code")
+        .last()
+    )
+    stats_dict["countries_debt_vs_education"] = int(
+        (edu_compare["debt service"] > edu_compare["education"]).sum()
+    )
+
     stats_dict["latest_year"] = LATEST_YEAR  # latest year of data
 
     with open(Paths.output / "key_stats.json", "w") as f:


### PR DESCRIPTION
This pull request adds new statistical calculations to the `key_stats` output, specifically tracking the number of countries where debt service exceeds government spending on health or education. It also updates the `key_stats.json` file to include these new metrics and refreshes the last data update timestamp.

New statistical metrics:

* Added calculation for the number of countries where debt service exceeds health spending, based on the latest available year per country (`countries_debt_vs_health`).
* Added calculation for the number of countries where debt service exceeds education spending, based on the latest available year per country (`countries_debt_vs_education`).

Output update:

* Updated `output/key_stats.json` to include the new metrics (`countries_debt_vs_health`, `countries_debt_vs_education`) and refreshed the `last_data_update` field.